### PR TITLE
Missing bytecode of sources for dependece scan is no longer fatal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
-assembly.iml
+*.iml
 target/
 **/*.class

--- a/api/src/main/java/io/github/mkoncek/classpathless/api/ClassesProvider.java
+++ b/api/src/main/java/io/github/mkoncek/classpathless/api/ClassesProvider.java
@@ -23,8 +23,8 @@ public interface ClassesProvider {
      * Callback for compiler which provides, on demand, the dependencies the
      * compiler is missing.
      *
-     * @param names Names of classes the provider should return
-     * @return The bytecode files of all found classes
+     * @param names Names of classes the provider should return.
+     * @return The bytecode files of all found classes. Must not be null.
      */
     Collection<IdentifiedBytecode> getClass(ClassIdentifier... names);
 
@@ -32,7 +32,7 @@ public interface ClassesProvider {
      * Warning: may include lambdas and will include inner classes with $-notations.
      * Intentionally not using ClassIdentifier, but may change to it.
      *
-     * @return All fully qualified classes visible from the provider's classpath
+     * @return All fully qualified classes visible from the provider's classpath.
      */
     List<String> getClassPathListing();
 }

--- a/api/src/main/java/io/github/mkoncek/classpathless/api/IdentifiedSource.java
+++ b/api/src/main/java/io/github/mkoncek/classpathless/api/IdentifiedSource.java
@@ -23,14 +23,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * Java source file with its fully qualified name.
  */
-@SuppressFBWarnings(value = {"EQ_DOESNT_OVERRIDE_EQUALS"}, justification = "intentionally using equals from superclass")
+@SuppressFBWarnings(value = {"EQ_DOESNT_OVERRIDE_EQUALS"},
+    justification = "intentionally using equals from superclass")
 public class IdentifiedSource extends IdentifiedFile {
     private final Charset charset;
 
     /**
      * @param classIdentifier fully qualified name of class.
      * @param file java source code of class.
-     * @param charset charset of source which was used to get the byte[].
+     * @param charset Character set of source which was used to get the byte[].
      * Default encoding is used if not provided.
      */
     public IdentifiedSource(ClassIdentifier classIdentifier, byte[] file, Charset charset) {

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/impl/src/main/java/io/github/mkoncek/classpathless/impl/CompilerJavac.java
+++ b/impl/src/main/java/io/github/mkoncek/classpathless/impl/CompilerJavac.java
@@ -157,7 +157,7 @@ public class CompilerJavac implements ClasspathlessCompiler {
         try {
             availableClasses.addAll(extractAllDependencies(classesProvider, loggingSwitch, bytecode));
         } catch (Exception ex) {
-            loggingSwitch.logln(Level.SEVERE, "An exception was thrown during the retrieval of referenced classes of bytecode {0} for source {1}: {2}",
+            loggingSwitch.logln(Level.SEVERE, "An exception was thrown during the retrieval of referenced classes of bytecode '{0}' for source '{1}': '{2}'",
                     bytecode.getClassIdentifier().getFullName(),
                     source.getClassIdentifier().getFullName(),
                     ex.toString());
@@ -166,20 +166,20 @@ public class CompilerJavac implements ClasspathlessCompiler {
 
     private static Collection<String> extractAllDependencies(ClassesProvider classesProvider, LoggingSwitch loggingSwitch, IdentifiedBytecode bytecode) {
         return BytecodeExtractorAccessor.extractDependenciesImpl(bytecode, classesProvider,
-                groupMember -> loggingSwitch.logln(Level.FINE, "Adding class to classpath listing (nested group): {0}", groupMember),
-                directlyReferenced -> loggingSwitch.logln(Level.FINE, "Adding class to classpath listing (directly referenced): {0}",
+                groupMember -> loggingSwitch.logln(Level.FINE, "Adding class to classpath listing (nested group): '{0}'", groupMember),
+                directlyReferenced -> loggingSwitch.logln(Level.FINE, "Adding class to classpath listing (directly referenced): '{0}'",
                         directlyReferenced), referencedOuter -> loggingSwitch.logln(Level.FINE,
-                        "Adding class to classpath listing (outer class of directly referenced): {0}", referencedOuter));
+                        "Adding class to classpath listing (outer class of directly referenced): '{0}'", referencedOuter));
     }
 
     private static boolean isBytecodeValid(IdentifiedBytecode bytecode, LoggingSwitch loggingSwitch, IdentifiedSource source) {
         if (bytecode == null) {
-            loggingSwitch.logln(Level.WARNING, "ClassesProvider::getClass returned list contains null object for source {0}",
+            loggingSwitch.logln(Level.WARNING, "ClassesProvider::getClass returned list contains null object for source '{0}'",
                     source.getClassIdentifier().getFullName());
             return false;
         } else if (bytecode.getFile().length < 4) {
             // 0xCAFEBABE
-            loggingSwitch.logln(Level.SEVERE, "Ignoring invalid bytecode {0} for source {1}",
+            loggingSwitch.logln(Level.SEVERE, "Ignoring invalid bytecode '{0}' for source '{1}'",
                     bytecode.getClassIdentifier().getFullName(),
                     source.getClassIdentifier().getFullName());
             return false;
@@ -189,7 +189,7 @@ public class CompilerJavac implements ClasspathlessCompiler {
 
     private static boolean areBytecodesValid(LoggingSwitch loggingSwitch, IdentifiedSource source, Collection<IdentifiedBytecode> bytecodes) {
         if (bytecodes == null) {
-            loggingSwitch.logln(Level.WARNING, "ClassesProvider::getClass returned null for source {0}",
+            loggingSwitch.logln(Level.WARNING, "ClassesProvider::getClass returned null for source '{0}'",
                     source.getClassIdentifier().getFullName());
             return false;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -84,27 +84,27 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.11.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.1.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.5.0</version>
         <configuration>
           <quiet>true</quiet>
           <tags>
@@ -128,7 +128,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -142,16 +142,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>3.3.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.0.1</version>
         <configuration>
           <tagNameFormat>@{project.version}</tagNameFormat>
         </configuration>
@@ -159,7 +159,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
         <configuration>
           <keyname>${gpg.keyname}</keyname>
         </configuration>
@@ -176,7 +176,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
-      <version>9.2</version>
+      <version>9.5</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
If class is compiled, whcih was originally not on original CP, compilation fails,  because no bytecode is returned from ClassesProvider and thus objectweb asm is trying to read in byte[0] or in null.

The PR shoudl be making this case non fatal. See the example of our JRD friednd:
```
package [org.jrd.frontend.frame.main.renderer](http://org.jrd.frontend.frame.main.renderer/);
public class VmListRenderer {
    
}
```
will compile  (against JRD)

however
```
public class a {
}

```
not

The exception was
```
removing -target and 11
removing -source and 11
compiler args: -source 11 -target 11 -verbose
 restoring agent verified on : localhost:10900
 restored agent verified on : localhost:10900
Processing request. VM ID: 15866, PID: 15866, action: BYTES, port: 10900
java.lang.RuntimeException: Class org.jrd.frontend.frame.main.renderer.a not found in loaded classes.
    at org.jrd.agent.InstrumentationProvider.findClass(InstrumentationProvider.java:90)
    at org.jrd.agent.InstrumentationProvider.findClassBody(InstrumentationProvider.java:79)
    at org.jrd.agent.AgentActionWorker.sendByteCode(AgentActionWorker.java:230)
    at org.jrd.agent.AgentActionWorker.writeToStreamBasedOnLine(AgentActionWorker.java:131)
    at org.jrd.agent.AgentActionWorker.executeRequest(AgentActionWorker.java:95)
    at org.jrd.agent.AgentActionWorker.<init>(AgentActionWorker.java:44)
    at org.jrd.agent.ConnectionDelegator.run(ConnectionDelegator.java:77)
java.lang.RuntimeException: Agent returned error in response header: java.lang.RuntimeException: Class org.jrd.frontend.frame.main.renderer.a not found in loaded classes.
    at org.jrd.backend.communication.Communicate.readResponse(Communicate.java:120)
    at org.jrd.backend.communication.CallDecompilerAgent.submitRequest(CallDecompilerAgent.java:48)
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:170)
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:149)
    at org.jrd.backend.core.DecompilerRequestReceiver.getByteCodeAction(DecompilerRequestReceiver.java:240)
    at org.jrd.backend.core.DecompilerRequestReceiver.processRequest(DecompilerRequestReceiver.java:84)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.submitRequest(DecompilationController.java:746)
    at org.jrd.backend.data.cli.Lib.obtainClass(Lib.java:286)
    at org.jrd.backend.communication.RuntimeCompilerConnector$JrdClassesProvider.getClass(RuntimeCompilerConnector.java:56)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getSingleClassFromRunningVmCatched(DecompilationController.java:544)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getClassItself(DecompilationController.java:533)
    at org.jrd.frontend.frame.main.decompilerview.dummycompiler.ClassesAndMethodsProviderBasedClassesProvider.getClass(ClassesAndMethodsProviderBasedClassesProvider.java:28)
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:86)
    at org.jrd.frontend.frame.overwrite.OverwriteClassDialog$CompilationWithResult.run(OverwriteClassDialog.java:562)
    at org.jrd.frontend.frame.main.decompilerview.QuickCompiler$2.run(QuickCompiler.java:55)
    at java.base/…829)
java.lang.RuntimeException: Agent returned error response 'java.lang.RuntimeException: Class org.jrd.frontend.frame.main.renderer.a not found in loaded classes.' for request 'BYTES\norg.jrd.frontend.frame.main.renderer.a'.
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:175)
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:149)
    at org.jrd.backend.core.DecompilerRequestReceiver.getByteCodeAction(DecompilerRequestReceiver.java:240)
    at org.jrd.backend.core.DecompilerRequestReceiver.processRequest(DecompilerRequestReceiver.java:84)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.submitRequest(DecompilationController.java:746)
    at org.jrd.backend.data.cli.Lib.obtainClass(Lib.java:286)
    at org.jrd.backend.communication.RuntimeCompilerConnector$JrdClassesProvider.getClass(RuntimeCompilerConnector.java:56)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getSingleClassFromRunningVmCatched(DecompilationController.java:544)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getClassItself(DecompilationController.java:533)
    at org.jrd.frontend.frame.main.decompilerview.dummycompiler.ClassesAndMethodsProviderBasedClassesProvider.getClass(ClassesAndMethodsProviderBasedClassesProvider.java:28)
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:86)
    at org.jrd.frontend.frame.overwrite.OverwriteClassDialog$CompilationWithResult.run(OverwriteClassDialog.java:562)
    at org.jrd.frontend.frame.main.decompilerview.QuickCompiler$2.run(QuickCompiler.java:55)
    at java.base/…829)
java.lang.RuntimeException: Classes couldn't be loaded.Do you have agent configured?On JDK 9 and higher, did you run the target process with '-Djdk.attach.allowAttachSelf=true'? Or maybe agent is not loaded? Or bad agent?
    at org.jrd.backend.data.cli.Lib.obtainClass(Lib.java:290)
    at org.jrd.backend.communication.RuntimeCompilerConnector$JrdClassesProvider.getClass(RuntimeCompilerConnector.java:56)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getSingleClassFromRunningVmCatched(DecompilationController.java:544)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getClassItself(DecompilationController.java:533)
    at org.jrd.frontend.frame.main.decompilerview.dummycompiler.ClassesAndMethodsProviderBasedClassesProvider.getClass(ClassesAndMethodsProviderBasedClassesProvider.java:28)
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:86)
    at org.jrd.frontend.frame.overwrite.OverwriteClassDialog$CompilationWithResult.run(OverwriteClassDialog.java:562)
    at org.jrd.frontend.frame.main.decompilerview.QuickCompiler$2.run(QuickCompiler.java:55)
    at java.base/…829)
Attempting to init the class and load again
 restoring agent verified on : localhost:10900
 restored agent verified on : localhost:10900
Processing request. VM ID: 15866, PID: 15866, action: INIT_CLASS, port: 10900
java.lang.ClassNotFoundException: org.jrd.frontend.frame.main.renderer.a
    at java.base/…581)
    at java.base/…178)
    at java.base/…522)
    at java.base/…ive Method)
    at java.base/…315)
    at org.jrd.agent.AgentActionWorker$4.run(AgentActionWorker.java:284)
    at org.jrd.agent.AgentActionWorker.executeParametrisedNoReturnCommand(AgentActionWorker.java:270)
    at org.jrd.agent.AgentActionWorker.initClass(AgentActionWorker.java:281)
    at org.jrd.agent.AgentActionWorker.writeToStreamBasedOnLine(AgentActionWorker.java:146)
    at org.jrd.agent.AgentActionWorker.executeRequest(AgentActionWorker.java:95)
    at org.jrd.agent.AgentActionWorker.<init>(AgentActionWorker.java:44)
    at org.jrd.agent.ConnectionDelegator.run(ConnectionDelegator.java:77)
java.lang.RuntimeException: Agent returned error in response header: java.lang.ClassNotFoundException: org.jrd.frontend.frame.main.renderer.a
    at org.jrd.backend.communication.Communicate.readResponse(Communicate.java:120)
    at org.jrd.backend.communication.CallDecompilerAgent.submitRequest(CallDecompilerAgent.java:48)
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:170)
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:149)
    at org.jrd.backend.core.DecompilerRequestReceiver.getNoReplyValue(DecompilerRequestReceiver.java:225)
    at org.jrd.backend.core.DecompilerRequestReceiver.getInitAction(DecompilerRequestReceiver.java:220)
    at org.jrd.backend.core.DecompilerRequestReceiver.processRequest(DecompilerRequestReceiver.java:77)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.submitRequest(DecompilationController.java:746)
    at org.jrd.backend.data.cli.Lib.initClassNoThrow(Lib.java:61)
    at org.jrd.backend.data.cli.Lib.initClass(Lib.java:49)
    at org.jrd.backend.communication.RuntimeCompilerConnector$JrdClassesProvider.getClass(RuntimeCompilerConnector.java:61)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getSingleClassFromRunningVmCatched(DecompilationController.java:544)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getClassItself(DecompilationController.java:533)
    at org.jrd.frontend.frame.main.decompilerview.dummycompiler.ClassesAndMethodsProviderBasedClassesProvider.getClass(ClassesAndMethodsProviderBasedClassesProvider.java:28)
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:86)
    at org.jrd.frontend.frame.overwrite.OverwriteClassDialog$CompilationWithResult.run(OverwriteClassDialog.java:562)
    at org.jrd.frontend.frame.main.decompilerview.QuickCompiler$2.run(QuickCompiler.java:55)
    at java.base/…829)
java.lang.RuntimeException: Agent returned error response 'java.lang.ClassNotFoundException: org.jrd.frontend.frame.main.renderer.a' for request 'INIT_CLASS\norg.jrd.frontend.frame.main.renderer.a'.
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:175)
    at org.jrd.backend.core.DecompilerRequestReceiver.getResponse(DecompilerRequestReceiver.java:149)
    at org.jrd.backend.core.DecompilerRequestReceiver.getNoReplyValue(DecompilerRequestReceiver.java:225)
    at org.jrd.backend.core.DecompilerRequestReceiver.getInitAction(DecompilerRequestReceiver.java:220)
    at org.jrd.backend.core.DecompilerRequestReceiver.processRequest(DecompilerRequestReceiver.java:77)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.submitRequest(DecompilationController.java:746)
    at org.jrd.backend.data.cli.Lib.initClassNoThrow(Lib.java:61)
    at org.jrd.backend.data.cli.Lib.initClass(Lib.java:49)
    at org.jrd.backend.communication.RuntimeCompilerConnector$JrdClassesProvider.getClass(RuntimeCompilerConnector.java:61)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getSingleClassFromRunningVmCatched(DecompilationController.java:544)
    at org.jrd.frontend.frame.main.decompilerview.DecompilationController.getClassItself(DecompilationController.java:533)
    at org.jrd.frontend.frame.main.decompilerview.dummycompiler.ClassesAndMethodsProviderBasedClassesProvider.getClass(ClassesAndMethodsProviderBasedClassesProvider.java:28)
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:86)
    at org.jrd.frontend.frame.overwrite.OverwriteClassDialog$CompilationWithResult.run(OverwriteClassDialog.java:562)
    at org.jrd.frontend.frame.main.decompilerview.QuickCompiler$2.run(QuickCompiler.java:55)
    at java.base/…829)
Init of class 'org.jrd.frontend.frame.main.renderer.a' failed, not obtaining.
java.lang.RuntimeException: java.lang.ArrayIndexOutOfBoundsException: Index 6 out of bounds for length 0
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:142)
    at org.jrd.frontend.frame.overwrite.OverwriteClassDialog$CompilationWithResult.run(OverwriteClassDialog.java:562)
    at org.jrd.frontend.frame.main.decompilerview.QuickCompiler$2.run(QuickCompiler.java:55)
    at java.base/…829)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 6 out of bounds for length 0
    at org.objectweb.asm.ClassReader.readShort(ClassReader.java:3608)
    at org.objectweb.asm.ClassReader.<init>(ClassReader.java:197)
    at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
    at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
    at io.github.mkoncek.classpathless.util.BytecodeExtractor.extractOuterClass(BytecodeExtractor.java:216)
    at io.github.mkoncek.classpathless.util.BytecodeExtractor.extractFullClassGroup(BytecodeExtractor.java:268)
    at io.github.mkoncek.classpathless.util.BytecodeExtractor.extractDependenciesImpl(BytecodeExtractor.java:311)
    at io.github.mkoncek.classpathless.util.BytecodeExtractorAccessor.extractDependenciesImpl(BytecodeExtractorAccessor.java:28)
    at io.github.mkoncek.classpathless.impl.CompilerJavac.compileClass(CompilerJavac.java:87)
    ... 3 more
Attempt to compile failed with - java.lang.ArrayIndexOutOfBoundsException: Index 6 out of bounds for length 0.
```

